### PR TITLE
fix train_index_only

### DIFF
--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -34,7 +34,7 @@ class Training(Tab):
         def train_index_only(
             model_name,
             target_sr,
-            dataset_dir,
+            dataset_glob,
             num_cpu_process,
             pitch_extraction_algo,
             ignore_cache,
@@ -47,7 +47,7 @@ class Training(Tab):
 
             os.makedirs(training_dir, exist_ok=True)
 
-            datasets = glob_dataset(dataset_glob, SR_DICT[target_sr])
+            datasets = glob_dataset(dataset_glob)
 
             yield "Preprocessing..."
             preprocess_dataset(


### PR DESCRIPTION
Train Index を実行すると `train_index_only` でエラーが出るので `train_all` を参考に直してみました。
big.npy、indexとも正常に書き出されました。