### PR TITLE
add support 768-th vector phone embeddings such as the contentvec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 tmp/
 
 models/hubert_base.pt
+models/checkpoint_best_legacy_500.pt

--- a/configs/32k-768.json
+++ b/configs/32k-768.json
@@ -41,7 +41,7 @@
     "upsample_kernel_sizes": [16,16,4,4,4],
     "use_spectral_norm": false,
     "gin_channels": 256,
-    "emb_channels": 256,
+    "emb_channels": 768,
     "spk_embed_dim": 109
   }
 }

--- a/configs/40k-768.json
+++ b/configs/40k-768.json
@@ -17,11 +17,11 @@
   },
   "data": {
     "max_wav_value": 32768.0,
-    "sampling_rate": 32000,
-    "filter_length": 1024,
-    "hop_length": 320,
-    "win_length": 1024,
-    "n_mel_channels": 80,
+    "sampling_rate": 40000,
+    "filter_length": 2048,
+    "hop_length": 400,
+    "win_length": 2048,
+    "n_mel_channels": 125,
     "mel_fmin": 0.0,
     "mel_fmax": null
   },
@@ -36,12 +36,12 @@
     "resblock": "1",
     "resblock_kernel_sizes": [3,7,11],
     "resblock_dilation_sizes": [[1,3,5], [1,3,5], [1,3,5]],
-    "upsample_rates": [10,4,2,2,2],
+    "upsample_rates": [10,10,2,2],
     "upsample_initial_channel": 512,
-    "upsample_kernel_sizes": [16,16,4,4,4],
+    "upsample_kernel_sizes": [16,16,4,4],
     "use_spectral_norm": false,
     "gin_channels": 256,
-    "emb_channels": 256,
+    "emb_channels": 768,
     "spk_embed_dim": 109
   }
 }

--- a/configs/40k.json
+++ b/configs/40k.json
@@ -41,6 +41,7 @@
     "upsample_kernel_sizes": [16,16,4,4],
     "use_spectral_norm": false,
     "gin_channels": 256,
+    "emb_channels": 256,
     "spk_embed_dim": 109
   }
 }

--- a/configs/48k-768.json
+++ b/configs/48k-768.json
@@ -9,7 +9,7 @@
     "batch_size": 4,
     "fp16_run": true,
     "lr_decay": 0.999875,
-    "segment_size": 12800,
+    "segment_size": 11520,
     "init_lr_ratio": 1,
     "warmup_epochs": 0,
     "c_mel": 45,
@@ -17,11 +17,11 @@
   },
   "data": {
     "max_wav_value": 32768.0,
-    "sampling_rate": 32000,
-    "filter_length": 1024,
-    "hop_length": 320,
-    "win_length": 1024,
-    "n_mel_channels": 80,
+    "sampling_rate": 48000,
+    "filter_length": 2048,
+    "hop_length": 480,
+    "win_length": 2048,
+    "n_mel_channels": 128,
     "mel_fmin": 0.0,
     "mel_fmax": null
   },
@@ -36,12 +36,12 @@
     "resblock": "1",
     "resblock_kernel_sizes": [3,7,11],
     "resblock_dilation_sizes": [[1,3,5], [1,3,5], [1,3,5]],
-    "upsample_rates": [10,4,2,2,2],
+    "upsample_rates": [10,6,2,2,2],
     "upsample_initial_channel": 512,
     "upsample_kernel_sizes": [16,16,4,4,4],
     "use_spectral_norm": false,
     "gin_channels": 256,
-    "emb_channels": 256,
+    "emb_channels": 768,
     "spk_embed_dim": 109
   }
 }

--- a/configs/48k.json
+++ b/configs/48k.json
@@ -41,6 +41,7 @@
     "upsample_kernel_sizes": [16,16,4,4,4],
     "use_spectral_norm": false,
     "gin_channels": 256,
+    "emb_channels": 256,
     "spk_embed_dim": 109
   }
 }

--- a/modules/inference/models.py
+++ b/modules/inference/models.py
@@ -17,6 +17,7 @@ class TextEncoder256(nn.Module):
         out_channels,
         hidden_channels,
         filter_channels,
+        emb_channels,
         n_heads,
         n_layers,
         kernel_size,
@@ -27,11 +28,12 @@ class TextEncoder256(nn.Module):
         self.out_channels = out_channels
         self.hidden_channels = hidden_channels
         self.filter_channels = filter_channels
+        self.emb_channels = emb_channels
         self.n_heads = n_heads
         self.n_layers = n_layers
         self.kernel_size = kernel_size
         self.p_dropout = p_dropout
-        self.emb_phone = nn.Linear(256, hidden_channels)
+        self.emb_phone = nn.Linear(emb_channels, hidden_channels)
         self.lrelu = nn.LeakyReLU(0.1, inplace=True)
         if f0 == True:
             self.emb_pitch = nn.Embedding(256, hidden_channels)  # pitch 256
@@ -64,6 +66,7 @@ class TextEncoder256Sim(nn.Module):
         out_channels,
         hidden_channels,
         filter_channels,
+        emb_channels,
         n_heads,
         n_layers,
         kernel_size,
@@ -74,11 +77,12 @@ class TextEncoder256Sim(nn.Module):
         self.out_channels = out_channels
         self.hidden_channels = hidden_channels
         self.filter_channels = filter_channels
+        self.emb_channels = emb_channels
         self.n_heads = n_heads
         self.n_layers = n_layers
         self.kernel_size = kernel_size
         self.p_dropout = p_dropout
-        self.emb_phone = nn.Linear(256, hidden_channels)
+        self.emb_phone = nn.Linear(emb_channels, hidden_channels)
         self.lrelu = nn.LeakyReLU(0.1, inplace=True)
         if f0 == True:
             self.emb_pitch = nn.Embedding(256, hidden_channels)  # pitch 256
@@ -544,6 +548,7 @@ class SynthesizerTrnMs256NSFSid(nn.Module):
         upsample_kernel_sizes,
         spk_embed_dim,
         gin_channels,
+        emb_channels,
         sr,
         **kwargs
     ):
@@ -566,12 +571,14 @@ class SynthesizerTrnMs256NSFSid(nn.Module):
         self.upsample_kernel_sizes = upsample_kernel_sizes
         self.segment_size = segment_size
         self.gin_channels = gin_channels
+        self.emb_channels = emb_channels
         # self.hop_length = hop_length#
         self.spk_embed_dim = spk_embed_dim
         self.enc_p = TextEncoder256(
             inter_channels,
             hidden_channels,
             filter_channels,
+            emb_channels,
             n_heads,
             n_layers,
             kernel_size,
@@ -655,6 +662,7 @@ class SynthesizerTrnMs256NSFSidNono(nn.Module):
         upsample_kernel_sizes,
         spk_embed_dim,
         gin_channels,
+        emb_channels,
         sr=None,
         **kwargs
     ):
@@ -675,12 +683,14 @@ class SynthesizerTrnMs256NSFSidNono(nn.Module):
         self.upsample_kernel_sizes = upsample_kernel_sizes
         self.segment_size = segment_size
         self.gin_channels = gin_channels
+        self.emb_channels = emb_channels
         # self.hop_length = hop_length#
         self.spk_embed_dim = spk_embed_dim
         self.enc_p = TextEncoder256(
             inter_channels,
             hidden_channels,
             filter_channels,
+            emb_channels,
             n_heads,
             n_layers,
             kernel_size,
@@ -761,6 +771,7 @@ class SynthesizerTrnMs256NSFSidSim(nn.Module):
         upsample_kernel_sizes,
         spk_embed_dim,
         # hop_length,
+        emb_channels,
         gin_channels=0,
         use_sdp=True,
         **kwargs
@@ -782,12 +793,14 @@ class SynthesizerTrnMs256NSFSidSim(nn.Module):
         self.upsample_kernel_sizes = upsample_kernel_sizes
         self.segment_size = segment_size
         self.gin_channels = gin_channels
+        self.emb_channels = emb_channels
         # self.hop_length = hop_length#
         self.spk_embed_dim = spk_embed_dim
         self.enc_p = TextEncoder256Sim(
             inter_channels,
             hidden_channels,
             filter_channels,
+            emb_channels,
             n_heads,
             n_layers,
             kernel_size,

--- a/modules/training/checkpoints.py
+++ b/modules/training/checkpoints.py
@@ -10,7 +10,7 @@ def write_config(state_dict: Dict[str, Any], cfg: Dict[str, Any]):
     state_dict["params"] = cfg
 
 
-def create_trained_model(weights: Dict[str, Any], sr: int, f0: int, epoch: int):
+def create_trained_model(weights: Dict[str, Any], sr: int, f0: int, emb_name: str, emb_ch: int, epoch: int):
     state_dict = OrderedDict()
     state_dict["weight"] = {}
     for key in weights.keys():
@@ -38,6 +38,7 @@ def create_trained_model(weights: Dict[str, Any], sr: int, f0: int, epoch: int):
                 "upsample_kernel_sizes": [16, 16, 4, 4],
                 "spk_embed_dim": 109,
                 "gin_channels": 256,
+                "emb_channels": emb_ch,
                 "sr": 40000,
             },
         )
@@ -62,6 +63,7 @@ def create_trained_model(weights: Dict[str, Any], sr: int, f0: int, epoch: int):
                 "upsample_kernel_sizes": [16, 16, 4, 4, 4],
                 "spk_embed_dim": 109,
                 "gin_channels": 256,
+                "emb_channels": emb_ch,
                 "sr": 48000,
             },
         )
@@ -86,21 +88,25 @@ def create_trained_model(weights: Dict[str, Any], sr: int, f0: int, epoch: int):
                 "upsample_kernel_sizes": [16, 16, 4, 4, 4],
                 "spk_embed_dim": 109,
                 "gin_channels": 256,
+                "emb_channels": emb_ch,
                 "sr": 32000,
             },
         )
     state_dict["info"] = f"{epoch}epoch"
     state_dict["sr"] = sr
     state_dict["f0"] = int(f0)
+    state_dict["embedder_name"] = emb_name
     return state_dict
 
 
-def save(model, sr: int, f0: int, filepath: str, epoch: int):
+def save(model, sr: int, f0: int, emb_name: str, emb_ch: int, filepath: str, epoch: int):
     if hasattr(model, "module"):
         state_dict = model.module.state_dict()
     else:
         state_dict = model.state_dict()
+        
+    print(f"save: emb_name: {emb_name} {emb_ch}")
 
-    state_dict = create_trained_model(state_dict, sr, f0, epoch)
+    state_dict = create_trained_model(state_dict, sr, f0, emb_name, emb_ch, epoch)
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
     torch.save(state_dict, filepath)

--- a/modules/training/config.py
+++ b/modules/training/config.py
@@ -47,6 +47,7 @@ class TrainConfigModel(BaseModel):
     upsample_kernel_sizes: List[int]
     use_spectral_norm: bool
     gin_channels: int
+    emb_channels: int
     spk_embed_dim: int
 
 
@@ -66,4 +67,4 @@ class DatasetMetaItem(BaseModel):
 
 class DatasetMetadata(BaseModel):
     files: Dict[str, DatasetMetaItem]
-    mute: DatasetMetaItem
+    # mute: DatasetMetaItem

--- a/modules/training/utils.py
+++ b/modules/training/utils.py
@@ -8,6 +8,7 @@ import matplotlib
 import matplotlib.pylab as plt
 import numpy as np
 import torch
+from torch.nn import functional as F
 from scipy.io.wavfile import read
 
 from modules.shared import ROOT_DIR
@@ -38,10 +39,26 @@ def load_checkpoint(checkpoint_path, model, optimizer=None, load_opt=1):
                 print(
                     f"shape-{k}-mismatch|need-{state_dict[k].shape}|get-{saved_state_dict[k].shape}"
                 )
-                raise KeyError
-        except:
+                if saved_state_dict[k].dim() == 2:  # NOTE: check is this ok?
+                    # for embedded input 256 <==> 768
+                    # this achieves we can continue training from original's pretrained checkpoints when using embedder that 768-th dim output etc.
+                    if saved_state_dict[k].dtype == torch.half:
+                        new_state_dict[k] = F.interpolate(saved_state_dict[k].float().unsqueeze(0).unsqueeze(0), size=state_dict[k].shape, mode="bilinear").half().squeeze(0).squeeze(0)
+                    else:
+                        new_state_dict[k] = F.interpolate(saved_state_dict[k].unsqueeze(0).unsqueeze(0), size=state_dict[k].shape, mode="bilinear").squeeze(0).squeeze(0)
+                    print(
+                        "interpolated new_state_dict", k,
+                        "from",
+                        saved_state_dict[k].shape,
+                        "to",
+                        new_state_dict[k].shape
+                    )
+                else:   
+                    raise KeyError
+        except Exception as e:
             # print(traceback.format_exc())
             print(f"{k} is not in the checkpoint")
+            print("error: %s" % e)
             new_state_dict[k] = v  # 模型自带的随机值
     if hasattr(model, "module"):
         model.module.load_state_dict(new_state_dict, strict=False)
@@ -146,8 +163,11 @@ def load_wav_to_torch(full_path):
     return torch.FloatTensor(data.astype(np.float32)), sampling_rate
 
 
-def load_config(training_dir: str, sample_rate: int):
-    config_path = os.path.join(ROOT_DIR, "configs", f"{sample_rate}.json")
+def load_config(training_dir: str, sample_rate: int, emb_channels: int):
+    if emb_channels == 256:
+        config_path = os.path.join(ROOT_DIR, "configs", f"{sample_rate}.json")
+    else:
+        config_path = os.path.join(ROOT_DIR, "configs", f"{sample_rate}-{emb_channels}.json")
     config_save_path = os.path.join(training_dir, "config.json")
 
     shutil.copyfile(config_path, config_save_path)


### PR DESCRIPTION
  - add Radio "Using phone embedder" to Training tab
  - add auto download the contentvec pt
  - add some configs
  - change model, pass embedder output dim size "emb_channels"
  - change the mute files processes
    - preprocess "models/mute/mute{sr}.wav" in the same way to other dataset files
  - add bi-linear interpolate when (pre-)train and now training target phone embedding size not matched

and some changes.

ja:
phone embeddingとして出力が768次元のものに対応しました。
- "Training"タブに"Using phone embedder"ラジオボタンを追加しました。
  - "hubert_base", "contentvec" とそれぞれの768次元出力を選択可能です。
  - ContentVec追加にともない、起動時のDL処理にContentVecもDLするようにしました。
  - ソースは仮で [https://huggingface.co/innnky/contentvec](https://huggingface.co/innnky/contentvec) に設定しています。元ソースはおそらく [https://github.com/auspicious3000/contentvec](https://github.com/auspicious3000/contentvec) こちらの `Model: ContentVec_legacy, Classes: 500` のものです。必要ならミラーなどしてください。

- 学習用のconfig `configs/{32, 40, 48}k-768.json` を追加しています。
  - 元のconfigに `model.emb_channels` を追加しています。

- モデルにemb_channels(phone embedding のチャネル数)を渡すように変更しています。
  - これに伴って、生成されるfeaturesファイル`3_feature256\*.npy`の次元が変わるので、mute ファイルも他のdatasetファイルと同じようにpreprocessするようにしました。(3_feature"256"は次元数を表しているような気がするので、変更してもいいかもしれません。)
  - 本家repoが用意してくださっているpretrained checkpointsをそのまま使用できるように一部stateをInterpolateするようにしています。学習継続できることを確認済みです。


以上、よろしければMergeお願いします。

P.S. 少し前のコミットに対して、複数話者同時学習を実装していたものも整理してPR予定です。