### PR TITLE
add support flac slicing to separator

### DIFF
--- a/modules/separate.py
+++ b/modules/separate.py
@@ -31,6 +31,8 @@ def separate_audio(
             audio = AudioSegment.from_mp3(file)
         elif os.path.splitext(file)[1] == ".wav":
             audio = AudioSegment.from_wav(file)
+        elif os.path.splitext(file)[1] == ".flac":
+            audio = AudioSegment.from_file(file, "flac")
         else:
             raise ValueError(
                 "Invalid file format. Only MP3 and WAV files are supported."


### PR DESCRIPTION
suggest:
  - "separator" tab => "slicer" tab, by word meaning. or, "dataset prep."?
  - (already can be) support other file formats. pydub internally converting input file by ffmpeg. If you acceptable, try to use pydub.from_file(<input file path>, <ext w/o period>)

ja: 
この前のPRのマージ、VC Clientとの互換対応、ありがとうございます。(ちなみにコードフォーマッターは何を使っていますか？)

このPRでは、個人的に使いたかったため、separator タブでの音声形式にFLACを追加しました。
提案なのですが、Issueにするほどでもないのでここで書きます。
- 言葉の意味合い的に"separator" タブは "slicer" タブ としたほうが良いと思います。
- separatorでの読み込みにpydubを使っているので、FLAC以外の音声(や動画など)フォーマットも読み込み可能と思われます。もしよろしければ、`pydub.from_file(<input file path>, <ext w/o period>)` を使って実装すると良いかと思います。

以上です。よろしくお願いします。