### PR TITLE
Add distilhubert and distilhubert-ja as feature extractor

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -105,6 +105,7 @@ class VC_MODEL:
             "contentvec768": ("checkpoint_best_legacy_500.pt", "contentvec"),
             "distilhubert": (load_transformers_hubert, "ntu-spml/distilhubert"),
             "distilhubert768": (load_transformers_hubert, "ntu-spml/distilhubert"),
+            "distilhubert-ja768": (load_transformers_hubert, "TylorShine/distilhubert-ft-japanese-50k"),
         }
         if not self.embedder_name in load_emb_dic.keys():
             raise Exception(f"Not supported embedder: {self.embedder_name}")
@@ -250,6 +251,22 @@ def load_transformers_hubert(repo_name, emb_name):
     embedder_model = (
         Wav2Vec2FeatureExtractor.from_pretrained(repo_name),
         HubertModel.from_pretrained(repo_name).to(device)
+    )
+    if is_half:
+        embedder_model[1].half()
+    else:
+        embedder_model[1].float()
+    embedder_model[1].eval()
+    
+    loaded_embedder_model = emb_name
+    
+    
+def load_transformers_hubert_local(dir_name, emb_name):
+    global embedder_model, loaded_embedder_model
+    dir_name = os.path.join(ROOT_DIR, "models", "pretrained", "feature_extractors", dir_name)
+    embedder_model = (
+        Wav2Vec2FeatureExtractor.from_pretrained(dir_name, local_files_only=True),
+        HubertModel.from_pretrained(dir_name, local_files_only=True).to(device)
     )
     if is_half:
         embedder_model[1].half()

--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -189,6 +189,7 @@ class Training(Tab):
                                 "hubert_base768",
                                 "contentvec768",
                                 "distilhubert768",
+                                "distilhubert-ja768",
                             ],
                             value="hubert_base",
                             label="Using phone embedder",

--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -188,6 +188,7 @@ class Training(Tab):
                                 "contentvec",
                                 "hubert_base768",
                                 "contentvec768",
+                                "distilhubert768",
                             ],
                             value="hubert_base",
                             label="Using phone embedder",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ soxr==0.3.5
 
 tensorboard
 tensorboardX
+transformers
 requests


### PR DESCRIPTION
- Add [distilhubert](https://arxiv.org/abs/2110.01900) [(Paper)](https://arxiv.org/abs/2110.01900) and [distilhubert-ja](https://huggingface.co/TylorShine/distilhubert-ft-japanese-50k) as feature extractor (embedder)
  - for this, add transformers to requirements.txt dependency
  - extraction speed is faster than contentvec and hubert_base
  - fine-tuned Japanese distilhubert was also added, I feel this is more natural transform than other (not train by Japanese) models in Japanese.

ja:
Feature Extractorとしてオリジナル(と思われる)distilHuBERTとそれを日本語でファインチューニングしたモデルを追加しました。
そのために、`transformers`が依存に追加されました。
ContentVecやHuBERT(base)と比べて、extraction速度が早いです。
日本語でファインチューニングしたdistliHuBERTモデルは(他の日本語でtrainされていないモデルより)日本語でより自然な変換ができると感じます。

よろしければMergeお願いします。