### PR TITLE
Fallback if out folder is not specified

### DIFF
--- a/modules/tabs/inference.py
+++ b/modules/tabs/inference.py
@@ -13,7 +13,7 @@ def inference_options_ui(show_out_dir=True):
         with gr.Column():
             source_audio = gr.Textbox(label="Source Audio")
             out_dir = gr.Textbox(
-                label="Out folder (Batch processing only)", visible=show_out_dir
+                label="Out folder", visible=show_out_dir, placeholder=models.AUDIO_OUT_DIR
             )
         with gr.Column():
             transpose = gr.Slider(
@@ -88,9 +88,8 @@ class Inference(Tab):
             model = models.vc_model
             try:
                 yield "Infering...", None
-
                 if out_dir == "":
-                    out_dir = None
+                    out_dir = models.AUDIO_OUT_DIR
 
                 if "*" in input_audio:
                     assert (


### PR DESCRIPTION
現状Source Audioにwavを指定する通常処理でもOut folderを指定しないとエラーになります。
Out folder未指定の場合の解決策は

- 初期値（AUDIO_OUT_DIR）で代替する（バッチ処理でも未指定ならここに書き出す）
- wav指定+Out folder未指定の時は書き出さない

のいずれかだと思います。

このPRではSource Audioの形態にかかわらずOut folderが未指定なら初期値（AUDIO_OUT_DIR）を使用します。