### PR TITLE
Add support japanese-hubert-base as feature

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -41,6 +41,18 @@ def download_models():
                 )
             )
 
+    # japanese-hubert-base (Fairseq)
+    # from official repo
+    # NOTE: change filename?
+    out = os.path.join(MODELS_DIR, "embeddings", "model.pt")
+    if not os.path.exists(out):
+        tasks.append(
+            (
+                f"https://huggingface.co/rinna/japanese-hubert-base/resolve/main/fairseq/model.pt",
+                out,
+            )
+        )
+
     if len(tasks) < 1:
         return
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -21,6 +21,7 @@ AUDIO_OUT_DIR = opts.output_dir or os.path.join(ROOT_DIR, "outputs")
 
 EMBEDDERS_LIST = {
     "hubert_base": ("hubert_base.pt", "hubert_base", "local"),
+    "hubert-base-japanese": ("model.pt", "hubert-base-japanese", "local"),
     "contentvec": ("checkpoint_best_legacy_500.pt", "contentvec", "local"),
     "distilhubert": ("ntu-spml/distilhubert", "distilhubert", "hf"),
     # "distilhubert-ja": ("TylorShine/distilhubert-ft-japanese-50k", "distilhubert-ja", "hf"),

--- a/modules/tabs/inference.py
+++ b/modules/tabs/inference.py
@@ -29,9 +29,10 @@ def inference_options_ui(show_out_dir=True):
             embedder_model = gr.Radio(
                 choices=[
                     "auto",
-                    "hubert_base",
+                    # "hubert_base",
                     "contentvec",
-                    "distilhubert",
+                    "hubert-base-japanese",
+                    # "distilhubert",
                     # "distilhubert-ja",
                     # "distilhubert-ja_dev",
                 ],

--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -230,13 +230,14 @@ class Training(Tab):
                         )
                         embedder_name = gr.Radio(
                             choices=[
-                                "hubert_base",
+                                # "hubert_base",
                                 "contentvec",
-                                "distilhubert",
+                                "hubert-base-japanese",
+                                # "distilhubert",
                                 # "distilhubert-ja",    # temporary
                                 # "distilhubert-ja_dev",
                             ],
-                            value="hubert_base",
+                            value="contentvec",
                             label="Using phone embedder",
                         )
                         embedding_channels = gr.Radio(


### PR DESCRIPTION
- add support japanese-hubert-base as feature extractor
  - official repo: https://huggingface.co/rinna/japanese-hubert-base
- drop hubert_base(=contentvec 500-classes model) and distilhubert from UI

日本語強化学習版のHuBERTに対応しました。
また、
- `hubert_base.pt` と `checkpoint_best_legacy_500.pt` (ContentVec) が同一ウェイトだった
- `distilhubert` モデルは公開されているモデルでは本使用方法には向かない
ということで、UIから`hubert_base`と`distilhubert`を削除し、`contentvec`(と`hubert-base-japanese`)のみとしています。