### PR TITLE
add change_pretrained() and add v1 urls into download_models()

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -41,6 +41,22 @@ def download_models():
     os.makedirs(os.path.join(MODELS_DIR, "pretrained", "v2"), exist_ok=True)
 
     tasks = []
+    for basename in [
+        f"{f0}{net}{rate}k{channels}"
+        for f0 in ["", "f0"]
+        for net in ["D", "G"]
+        for rate in [32, 40, 48]
+        for channels in [256, 768]
+    ]:
+
+        url = f"https://huggingface.co/ddPn08/rvc-webui-models/resolve/main/pretrained/v1/{basename}.pth"
+        out = os.path.join(MODELS_DIR, "pretrained", f"{basename}.pth")
+
+        if hash_check(url, out):
+            continue
+
+        tasks.append((url, out))
+
     for template in [
         "D{}k",
         "G{}k",
@@ -48,6 +64,7 @@ def download_models():
         "f0G{}k",
     ]:
         basename = template.format("40")
+
         url = f"https://huggingface.co/ddPn08/rvc-webui-models/resolve/main/pretrained/v2/{basename}.pth"
         out = os.path.join(MODELS_DIR, "pretrained", "v2", f"{basename}.pth")
 

--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -358,6 +358,40 @@ class Training(Tab):
                         train_index_button = gr.Button("Train Index", variant="primary")
                         train_all_button = gr.Button("Train", variant="primary")
 
+        def change_pretrained(v, sr, f0, emb_channels):
+            f0 = f0 == "Yes"
+            pretrained_dir = os.path.join("pretrained")
+            g = f"f0G{sr}{emb_channels}.pth" if f0 else f"G{sr}{emb_channels}.pth"
+            d = f"f0D{sr}{emb_channels}.pth" if f0 else f"D{sr}{emb_channels}.pth"
+
+            if v == "v2":
+                pretrained_dir = os.path.join("pretrained", "v2")
+                g = f"f0G{sr}.pth" if f0 else f"G{sr}.pth"
+                d = f"f0D{sr}.pth" if f0 else f"D{sr}.pth"
+
+            return gr.Textbox.update(
+                    value=os.path.join(MODELS_DIR, pretrained_dir, g)
+                ), gr.Textbox.update(value=os.path.join(MODELS_DIR, pretrained_dir, d))
+
+        change_pretrained_options = {
+            "fn": change_pretrained,
+            "inputs": [
+                version,
+                target_sr,
+                f0,
+                embedding_channels,
+            ],
+            "outputs": [
+                pre_trained_generator,
+                pre_trained_discriminator,
+            ],
+        }
+
+        version.change(**change_pretrained_options)
+        target_sr.change(**change_pretrained_options)
+        f0.change(**change_pretrained_options)
+        embedding_channels.change(**change_pretrained_options)
+
         train_index_button.click(
             train_index_only,
             inputs=[

--- a/modules/tabs/training.py
+++ b/modules/tabs/training.py
@@ -214,7 +214,7 @@ class Training(Tab):
             print(f"train_all: emb_name: {embedder_name}")
 
             config = utils.load_config(
-                version, training_dir, sampling_rate_str, embedding_channels, fp16
+                version, training_dir, sampling_rate_str, int(embedding_channels), fp16
             )
             out_dir = os.path.join(MODELS_DIR, "checkpoints")
 


### PR DESCRIPTION
1. Add missing function change_pretrained() in modules/tabs/training.py
2. Add v1 model URLs to download_models() in modules/core.py

You could also consider creating a v1 folder and placing it inside. See training.py:53 and core.py:363